### PR TITLE
Cache metamethods, finalize references

### DIFF
--- a/Eluant/LuaClrObjectValue.cs
+++ b/Eluant/LuaClrObjectValue.cs
@@ -1,10 +1,12 @@
 //
 // LuaClrObjectValue.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +27,8 @@
 // THE SOFTWARE.
 
 using System;
+using System.Linq;
+using Eluant.ObjectBinding;
 
 namespace Eluant
 {
@@ -53,6 +57,15 @@ namespace Eluant
         }
 
         internal abstract object BackingCustomObject { get; }
+
+        internal abstract MetamethodAttribute[] BackingCustomObjectMetamethods { get; }
+
+        static internal MetamethodAttribute[] Metamethods(Type backingCustomObjectType)
+        {
+            return backingCustomObjectType.GetInterfaces()
+                .SelectMany(iface => iface.GetCustomAttributes(typeof(MetamethodAttribute), false).Cast<MetamethodAttribute>())
+                .ToArray();
+        }
 
         internal override object ToClrType(Type type)
         {

--- a/Eluant/LuaClrObjectValue.cs
+++ b/Eluant/LuaClrObjectValue.cs
@@ -58,7 +58,7 @@ namespace Eluant
 
         internal abstract object BackingCustomObject { get; }
 
-        internal abstract MetamethodAttribute[] BackingCustomObjectMetamethods { get; }
+        internal abstract MetamethodAttribute[] BackingCustomObjectMetamethods(LuaRuntime runtime);
 
         static internal MetamethodAttribute[] Metamethods(Type backingCustomObjectType)
         {

--- a/Eluant/LuaCustomClrObject.cs
+++ b/Eluant/LuaCustomClrObject.cs
@@ -1,10 +1,12 @@
 //
 // LuaCustomClrObject.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +27,7 @@
 // THE SOFTWARE.
 
 using System;
+using Eluant.ObjectBinding;
 
 namespace Eluant
 {
@@ -50,6 +53,13 @@ namespace Eluant
         internal override object BackingCustomObject
         {
             get { return ClrObject; }
+        }
+
+        private MetamethodAttribute[] metamethods;
+
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
+        {
+            get { return metamethods ?? (metamethods = Metamethods(BackingCustomObject.GetType())); }
         }
     }
 }

--- a/Eluant/LuaCustomClrObject.cs
+++ b/Eluant/LuaCustomClrObject.cs
@@ -57,9 +57,9 @@ namespace Eluant
 
         private MetamethodAttribute[] metamethods;
 
-        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods(LuaRuntime runtime)
         {
-            get { return metamethods ?? (metamethods = Metamethods(BackingCustomObject.GetType())); }
+            return metamethods ?? (metamethods = runtime.CachedMetamethods(BackingCustomObject.GetType()));
         }
     }
 }

--- a/Eluant/LuaOpaqueClrObject.cs
+++ b/Eluant/LuaOpaqueClrObject.cs
@@ -55,9 +55,9 @@ namespace Eluant
             get { return null; }
         }
 
-        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods(LuaRuntime runtime)
         {
-            get { return null; }
+            return null;
         }
     }
 }

--- a/Eluant/LuaOpaqueClrObject.cs
+++ b/Eluant/LuaOpaqueClrObject.cs
@@ -1,10 +1,12 @@
 //
 // LuaOpaqueClrObject.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +27,7 @@
 // THE SOFTWARE.
 
 using System;
+using Eluant.ObjectBinding;
 
 namespace Eluant
 {
@@ -48,6 +51,11 @@ namespace Eluant
         }
 
         internal override object BackingCustomObject
+        {
+            get { return null; }
+        }
+
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
         {
             get { return null; }
         }

--- a/Eluant/LuaReference.cs
+++ b/Eluant/LuaReference.cs
@@ -1,10 +1,12 @@
 //
 // LuaReference.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -50,6 +52,7 @@ namespace Eluant
         public sealed override void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/Eluant/LuaRuntime.cs
+++ b/Eluant/LuaRuntime.cs
@@ -78,6 +78,7 @@ namespace Eluant
         private const string OPAQUECLROBJECT_METATABLE = "eluant_opaqueclrobject";
 
         private Dictionary<string, LuaFunction> metamethodCallbacks = new Dictionary<string, LuaFunction>();
+        private Dictionary<Type, MetamethodAttribute[]> metamethodAttributes = new Dictionary<Type, MetamethodAttribute[]>();
 
         private LuaFunction createManagedCallWrapper;
 
@@ -764,7 +765,7 @@ namespace Eluant
                 LuaApi.lua_settable(LuaState, -3);
 
                 // For all others, we use MetamethodAttribute on the interface to make this code less repetitive.
-                foreach (var metamethod in obj.BackingCustomObjectMetamethods) {
+                foreach (var metamethod in obj.BackingCustomObjectMetamethods(this)) {
                     LuaApi.lua_pushstring(LuaState, metamethod.MethodName);
                     Push(metamethodCallbacks[metamethod.MethodName]);
                     LuaApi.lua_settable(LuaState, -3);
@@ -775,6 +776,19 @@ namespace Eluant
                 objectReferenceManager.DestroyReference(reference);
                 throw;
             }
+        }
+
+        internal MetamethodAttribute[] CachedMetamethods(Type backingCustomObjectType)
+        {
+            MetamethodAttribute[] metamethods;
+            if (metamethodAttributes.TryGetValue(backingCustomObjectType, out metamethods)) {
+                return metamethods;
+            }
+
+            metamethods = LuaClrObjectValue.Metamethods(backingCustomObjectType);
+            metamethodAttributes.Add(backingCustomObjectType, metamethods);
+
+            return metamethods;
         }
 
         private int NewindexCallback(IntPtr state)

--- a/Eluant/LuaRuntime.cs
+++ b/Eluant/LuaRuntime.cs
@@ -1,10 +1,12 @@
 //
 // LuaRuntime.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -762,10 +764,7 @@ namespace Eluant
                 LuaApi.lua_settable(LuaState, -3);
 
                 // For all others, we use MetamethodAttribute on the interface to make this code less repetitive.
-                var metamethods = obj.BackingCustomObject.GetType().GetInterfaces()
-                    .SelectMany(iface => iface.GetCustomAttributes(typeof(MetamethodAttribute), false).Cast<MetamethodAttribute>());
-
-                foreach (var metamethod in metamethods) {
+                foreach (var metamethod in obj.BackingCustomObjectMetamethods) {
                     LuaApi.lua_pushstring(LuaState, metamethod.MethodName);
                     Push(metamethodCallbacks[metamethod.MethodName]);
                     LuaApi.lua_settable(LuaState, -3);

--- a/Eluant/LuaTransparentClrObject.cs
+++ b/Eluant/LuaTransparentClrObject.cs
@@ -73,9 +73,9 @@ namespace Eluant
             get { return proxy; }
         }
 
-        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods(LuaRuntime runtime)
         {
-            get { return TransparentClrObjectProxy.Metamethods; }
+            return TransparentClrObjectProxy.Metamethods;
         }
 
         private class TransparentClrObjectProxy : ILuaTableBinding, ILuaEqualityBinding

--- a/Eluant/LuaTransparentClrObject.cs
+++ b/Eluant/LuaTransparentClrObject.cs
@@ -1,10 +1,12 @@
 //
 // LuaTransparentClrObject.cs
 //
-// Author:
+// Authors:
 //       Chris Howie <me@chrishowie.com>
+//       Tom Roostan <RoosterDragon@outlook.com>
 //
 // Copyright (c) 2013 Chris Howie
+// Copyright (c) 2015 Tom Roostan
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -71,8 +73,15 @@ namespace Eluant
             get { return proxy; }
         }
 
+        internal override MetamethodAttribute[] BackingCustomObjectMetamethods
+        {
+            get { return TransparentClrObjectProxy.Metamethods; }
+        }
+
         private class TransparentClrObjectProxy : ILuaTableBinding, ILuaEqualityBinding
         {
+            public static readonly MetamethodAttribute[] Metamethods = LuaClrObjectValue.Metamethods(typeof(TransparentClrObjectProxy));
+
             private LuaTransparentClrObject clrObject;
 
             public TransparentClrObjectProxy(LuaTransparentClrObject obj)


### PR DESCRIPTION
This is a combination of a couple of PRs I submitted to [the OpenRA fork](https://github.com/OpenRA/Eluant) already. https://github.com/OpenRA/Eluant/pull/1, https://github.com/OpenRA/Eluant/pull/2.

This fixes a missing `SuppressFinalize` call, and implements caching of the `MetamethodAttribute` lookup. This lookup is extremely expensive. Most of our calls tend to marshal custom objects - I found without these changes we were spending more time just repeating this reflection call than we were actually spending invoking Lua code. Caching this provides a nice performance boost to calls involving custom objects.
